### PR TITLE
Add sample data

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,3 +9,4 @@ recursive-exclude * *.py[co]
 
 recursive-exclude .napari *
 exclude .pre-commit-config.yaml
+recursive-exclude examples *

--- a/brainreg_napari/napari.yaml
+++ b/brainreg_napari/napari.yaml
@@ -6,6 +6,15 @@ contributions:
     title: Atlas Registration
     python_name: brainreg_napari.register:brainreg_register
 
+  - id: brainreg-napari.SampleData
+    title: Sample data
+    python_name: brainreg_napari.sample_data:load_sample
+
   widgets:
   - command: brainreg-napari.Register
     display_name: Atlas Registration
+
+  sample_data:
+  - key: sample
+    display_name: Sample data
+    command: brainreg-napari.SampleData

--- a/brainreg_napari/napari.yaml
+++ b/brainreg_napari/napari.yaml
@@ -7,8 +7,8 @@ contributions:
     python_name: brainreg_napari.register:brainreg_register
 
   - id: brainreg-napari.SampleData
-    title: Sample data
-    python_name: brainreg_napari.sample_data:load_sample
+    title: Low resolution brain
+    python_name: brainreg_napari.sample_data:load_test_brain
 
   widgets:
   - command: brainreg-napari.Register
@@ -16,5 +16,5 @@ contributions:
 
   sample_data:
   - key: sample
-    display_name: Sample data
+    display_name: Low resolution brain
     command: brainreg-napari.SampleData

--- a/brainreg_napari/sample_data.py
+++ b/brainreg_napari/sample_data.py
@@ -16,7 +16,7 @@ POOCH_REGISTRY = pooch.create(
         f"raw/{data_commit_sha}/brainreg/"
     ),
     registry={
-        "test_brain.zip": "7bcfbc45bb40358cd8811e5264ca0a2367976db90bcefdcd67adf533e0162b5f"  # NoQA
+        "test_brain.zip": "7bcfbc45bb40358cd8811e5264ca0a2367976db90bcefdcd67adf533e0162b5f"  # noqa: E501
     },
 )
 

--- a/brainreg_napari/sample_data.py
+++ b/brainreg_napari/sample_data.py
@@ -5,7 +5,10 @@ import pooch
 from napari.types import LayerData
 from skimage.io import imread
 
-base_url = "https://raw.githubusercontent.com/brainglobe/brainreg/master/tests/data/brain%20data"
+base_url = (
+    "https://raw.githubusercontent.com/brainglobe/brainreg/master/"
+    "tests/data/brain%20data"
+)
 
 
 def load_sample() -> List[LayerData]:
@@ -19,4 +22,6 @@ def load_sample() -> List[LayerData]:
         data.append(imread(file))
 
     data = np.stack(data, axis=0)
-    return [(data, {"name": 'Sample brain'}), ]
+    return [
+        (data, {"name": "Sample brain"}),
+    ]

--- a/brainreg_napari/sample_data.py
+++ b/brainreg_napari/sample_data.py
@@ -1,0 +1,22 @@
+from typing import List
+
+import numpy as np
+import pooch
+from napari.types import LayerData
+from skimage.io import imread
+
+base_url = "https://raw.githubusercontent.com/brainglobe/brainreg/master/tests/data/brain%20data"
+
+
+def load_sample() -> List[LayerData]:
+    """
+    Load some sample data.
+    """
+    data = []
+    for i in range(270):
+        url = f"{base_url}/image_{str(i).zfill(4)}.tif"
+        file = pooch.retrieve(url=url, known_hash=None)
+        data.append(imread(file))
+
+    data = np.stack(data, axis=0)
+    return [(data, {"name": 'Sample brain'}), ]

--- a/brainreg_napari/sample_data.py
+++ b/brainreg_napari/sample_data.py
@@ -36,6 +36,7 @@ def load_test_brain() -> List[LayerData]:
                 data.append(imread(tif))
 
     data = np.stack(data, axis=0)
+    meta = {"voxel_size": [50, 40, 40], "data_orientation": "psl"}
     return [
-        (data, {"name": "Sample brain"}),
+        (data, {"name": "Sample brain", "metadata": meta}, "image"),
     ]

--- a/brainreg_napari/tests/test_brainreg_napari.py
+++ b/brainreg_napari/tests/test_brainreg_napari.py
@@ -1,5 +1,6 @@
+import napari
+
 from brainreg_napari.register import brainreg_register
-from brainreg_napari.sample_data import load_test_brain
 
 
 def test_add_detect_widget(make_napari_viewer):
@@ -11,11 +12,15 @@ def test_add_detect_widget(make_napari_viewer):
     viewer.window.add_dock_widget(widget)
 
 
-def test_get_sample_data():
+def test_napari_sample_data(make_napari_viewer):
     """
-    Check that fetching the test brain works.
+    Check that loading the sample data via napari works.
     """
-    layer_data_list = load_test_brain()
-    layer_data = layer_data_list[0]
-    assert layer_data[0].shape == (270, 193, 271)
-    assert layer_data[2] == "image"
+    viewer = make_napari_viewer()
+
+    assert len(viewer.layers) == 0
+    viewer.open_sample("brainreg-napari", "sample")
+    assert len(viewer.layers) == 1
+    new_layer = viewer.layers[0]
+    assert isinstance(new_layer, napari.layers.Image)
+    assert new_layer.data.shape == (270, 193, 271)

--- a/brainreg_napari/tests/test_brainreg_napari.py
+++ b/brainreg_napari/tests/test_brainreg_napari.py
@@ -1,4 +1,5 @@
 from brainreg_napari.register import brainreg_register
+from brainreg_napari.sample_data import load_test_brain
 
 
 def test_add_detect_widget(make_napari_viewer):
@@ -8,3 +9,13 @@ def test_add_detect_widget(make_napari_viewer):
     viewer = make_napari_viewer()
     widget = brainreg_register()
     viewer.window.add_dock_widget(widget)
+
+
+def test_get_sample_data():
+    """
+    Check that fetching the test brain works.
+    """
+    layer_data_list = load_test_brain()
+    layer_data = layer_data_list[0]
+    assert layer_data[0].shape == (270, 193, 271)
+    assert layer_data[2] == "image"

--- a/examples/load_sample_data.py
+++ b/examples/load_sample_data.py
@@ -8,18 +8,25 @@ This example:
 - opens the napari viewer
 """
 import napari
+from napari.layers import Layer
 
 from brainreg_napari.sample_data import load_test_brain
 
 viewer = napari.Viewer()
 # Open plugin
-viewer.window.add_plugin_dock_widget(
+_, brainreg_widget = viewer.window.add_plugin_dock_widget(
     plugin_name="brainreg-napari", widget_name="Atlas Registration"
 )
 # Add sample data layers
-for layer in load_test_brain():
-    viewer.add_layer(napari.layers.Image(layer[0], **layer[1]))
+for layer_data in load_test_brain():
+    viewer.add_layer(Layer.create(*layer_data))
 
+# Set brainreg-napari plugin settings from sample data metadata
+metadata = layer_data[1]["metadata"]
+brainreg_widget.data_orientation.value = metadata["data_orientation"]
+for i, dim in enumerate(["z", "y", "x"]):
+    pixel_widget = getattr(brainreg_widget, f"{dim}_pixel_um")
+    pixel_widget.value = metadata["voxel_size"][i]
 
 if __name__ == "__main__":
     # The napari event loop needs to be run under here to allow the window

--- a/examples/load_sample_data.py
+++ b/examples/load_sample_data.py
@@ -7,26 +7,31 @@ This example:
 - loads the brainreg-napari registration plugin
 - opens the napari viewer
 """
+import numpy as np
 import napari
 from napari.layers import Layer
 
 from brainreg_napari.sample_data import load_test_brain
 
 viewer = napari.Viewer()
+
+layer_data = load_test_brain()[0]
+# Set sensible contrast limits for viewing the brain
+layer_data[1]['contrast_limits'] = np.percentile(layer_data[0], [0, 99.5])
+# Add data to napari
+viewer.add_layer(Layer.create(*layer_data))
+
 # Open plugin
 _, brainreg_widget = viewer.window.add_plugin_dock_widget(
     plugin_name="brainreg-napari", widget_name="Atlas Registration"
 )
-# Add sample data layers
-for layer_data in load_test_brain():
-    viewer.add_layer(Layer.create(*layer_data))
-
 # Set brainreg-napari plugin settings from sample data metadata
 metadata = layer_data[1]["metadata"]
 brainreg_widget.data_orientation.value = metadata["data_orientation"]
 for i, dim in enumerate(["z", "y", "x"]):
     pixel_widget = getattr(brainreg_widget, f"{dim}_pixel_um")
     pixel_widget.value = metadata["voxel_size"][i]
+
 
 if __name__ == "__main__":
     # The napari event loop needs to be run under here to allow the window

--- a/examples/load_sample_data.py
+++ b/examples/load_sample_data.py
@@ -7,8 +7,8 @@ This example:
 - loads the brainreg-napari registration plugin
 - opens the napari viewer
 """
-import numpy as np
 import napari
+import numpy as np
 from napari.layers import Layer
 
 from brainreg_napari.sample_data import load_test_brain
@@ -17,7 +17,7 @@ viewer = napari.Viewer()
 
 layer_data = load_test_brain()[0]
 # Set sensible contrast limits for viewing the brain
-layer_data[1]['contrast_limits'] = np.percentile(layer_data[0], [0, 99.5])
+layer_data[1]["contrast_limits"] = np.percentile(layer_data[0], [0, 99.5])
 # Add data to napari
 viewer.add_layer(Layer.create(*layer_data))
 

--- a/examples/load_sample_data.py
+++ b/examples/load_sample_data.py
@@ -4,12 +4,12 @@ Load and show sample data
 This example:
 - loads some sample data
 - adds the data to a napari viewer
-- loads the brainreg-napari cell detection plugin
+- loads the brainreg-napari registration plugin
 - opens the napari viewer
 """
 import napari
 
-from brainreg_napari.sample_data import load_sample
+from brainreg_napari.sample_data import load_test_brain
 
 viewer = napari.Viewer()
 # Open plugin
@@ -17,7 +17,7 @@ viewer.window.add_plugin_dock_widget(
     plugin_name="brainreg-napari", widget_name="Atlas Registration"
 )
 # Add sample data layers
-for layer in load_sample():
+for layer in load_test_brain():
     viewer.add_layer(napari.layers.Image(layer[0], **layer[1]))
 
 

--- a/examples/registration.py
+++ b/examples/registration.py
@@ -1,0 +1,27 @@
+"""
+Load and show sample data
+=========================
+This example:
+- loads some sample data
+- adds the data to a napari viewer
+- loads the brainreg-napari cell detection plugin
+- opens the napari viewer
+"""
+import napari
+
+from brainreg_napari.sample_data import load_sample
+
+viewer = napari.Viewer()
+# Open plugin
+viewer.window.add_plugin_dock_widget(
+    plugin_name="brainreg-napari", widget_name="Atlas Registration"
+)
+# Add sample data layers
+for layer in load_sample():
+    viewer.add_layer(napari.layers.Image(layer[0], **layer[1]))
+
+
+if __name__ == "__main__":
+    # The napari event loop needs to be run under here to allow the window
+    # to be spawned from a Python script
+    napari.run()

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ requirements = [
     "napari-ndtiffs",
     "brainglobe-napari-io",
     "brainreg",
+    "pooch>1",  # For sample data
 ]
 
 setup(


### PR DESCRIPTION
This takes the sample data from the `brainreg` integration tests, and adds it to the sample data menu in napari. Depends on https://github.com/brainglobe/brainreg-napari/pull/32. Fixes https://github.com/brainglobe/brainreg-napari/issues/31