### PR TITLE
Make sure metadata is attached to loaded napari Layers

### DIFF
--- a/brainreg_napari/register.py
+++ b/brainreg_napari/register.py
@@ -327,19 +327,7 @@ def brainreg_register():
             )
 
         @thread_worker
-        def run(
-            affine_n_steps,
-            affine_use_n_steps,
-            freeform_n_steps,
-            freeform_use_n_steps,
-            bending_energy_weight,
-            grid_spacing,
-            smoothing_sigma_reference,
-            smoothing_sigma_floating,
-            histogram_n_bins_floating,
-            histogram_n_bins_reference,
-        ):
-
+        def run():
             paths = Paths(pathlib.Path(registration_output_folder))
 
             niftyreg_args = NiftyregArgs(
@@ -425,18 +413,7 @@ def brainreg_register():
                 f"{paths.registration_output_folder}"
             )
 
-        worker = run(
-            affine_n_steps,
-            affine_use_n_steps,
-            freeform_n_steps,
-            freeform_use_n_steps,
-            bending_energy_weight,
-            grid_spacing,
-            smoothing_sigma_reference,
-            smoothing_sigma_floating,
-            histogram_n_bins_floating,
-            histogram_n_bins_reference,
-        )
+        worker = run()
         worker.returned.connect(load_registration_as_layers)
         worker.start()
         if block:

--- a/brainreg_napari/register.py
+++ b/brainreg_napari/register.py
@@ -326,7 +326,6 @@ def brainreg_register():
                 args_dict,
             )
 
-        @thread_worker
         def run():
             paths = Paths(pathlib.Path(registration_output_folder))
 
@@ -413,11 +412,13 @@ def brainreg_register():
                 f"{paths.registration_output_folder}"
             )
 
-        worker = run()
-        worker.returned.connect(load_registration_as_layers)
-        worker.start()
         if block:
-            worker.await_workers()
+            run()
+            load_registration_as_layers()
+        else:
+            worker = thread_worker(worker)()
+            worker.returned.connect(load_registration_as_layers)
+            worker.start()
 
     @widget.reset_button.changed.connect
     def restore_defaults(event=None):

--- a/brainreg_napari/tests/test_brainreg_napari.py
+++ b/brainreg_napari/tests/test_brainreg_napari.py
@@ -50,5 +50,24 @@ def test_workflow(make_napari_viewer, tmp_path):
         pixel_widget = getattr(widget, f"{dim}_pixel_um")
         pixel_widget.value = brain_layer.metadata["voxel_size"][i]
 
+    assert len(viewer.layers) == 1
+
     # Run registration
     widget(block=True)
+
+    # Check that layers have been added
+    assert len(viewer.layers) == 3
+    # Check layers have expected type/name
+    labels = viewer.layers[1]
+    assert isinstance(labels, napari.layers.Labels)
+    assert labels.name == "example_mouse_100um"
+    for key in ["orientation", "atlas"]:
+        # There are lots of other keys in the metadata, but just check
+        # for a couple here.
+        assert (
+            key in labels.metadata
+        ), f"Missing key '{key}' from labels metadata"
+
+    boundaries = viewer.layers[2]
+    assert isinstance(boundaries, napari.layers.Image)
+    assert boundaries.name == "Boundaries"


### PR DESCRIPTION
## Description

This updates the way layers are added to make sure the `brainreg` metadata is stored in the layers. This is done by using the following code to add the layers:
```python
for layer in layers:
        viewer.add_layer(napari.layers.Layer.create(*layer))
```

**Why is this PR needed?**
A widget that takes brainreg output as input (e.g. https://github.com/brainglobe/cellfinder-napari/pull/117) needs access to this metadata.

## How has this PR been tested?

I've extended the current test to check for the right layers being added, and that metadata is stored on the labels layer.

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

If any features have changed, or have been added. Please explain how the documentation has been updated (and link to the associated PR). See [here](https://docs.cellfinder.info/for-developers/documentation) for details.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
