### PR TITLE
Prepare repository and package for retirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 As of the release of `brainreg` version `1.0.0`, `brainreg-napari` is now a part of [`brainreg`](https://github.com/brainglobe/brainreg).
 If you are looking to install the `brainglobe-napari` plugin, please install `brainreg` with it's optional `napari` dependency as detailed in the installation instructions on the [website](https://brainglobe.info/documentation/brainreg/index.html) or [repository](https://github.com/brainglobe/brainreg).
-Before you update, you should also remove the old `brianreg-napari` package from your environment using either
+Before you update, you should also remove the old `brainreg-napari` package from your environment using either
 
 ```bash
 python -m pip uninstall brainreg-napari # If you installed via pip

--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
+# THIS PACKAGE HAS MOVED
+
+As of the release of `brainreg` version `1.0.0`, `brainreg-napari` is now a part of [`brainreg`](https://github.com/brainglobe/brainreg).
+If you are looking to install the `brainglobe-napari` plugin, please install `brainreg` with it's optional `napari` dependency as detailed in the installation instructions on the [website](https://brainglobe.info/documentation/brainreg/index.html) or [repository](https://github.com/brainglobe/brainreg).
+Before you update, you should also remove the old `brianreg-napari` package from your environment using either
+
+```bash
+python -m pip uninstall brainreg-napari # If you installed via pip
+conda remove brainreg-napari # If you installed via conda
+```
+
+You can find the old documentation and installation instructions below, but please note this version of the package should be considered unmaintained.
+
+---
+
 [![Python Version](https://img.shields.io/pypi/pyversions/brainreg-napari.svg)](https://pypi.org/project/brainreg-napari)
 [![PyPI](https://img.shields.io/pypi/v/brainreg-napari.svg)](https://pypi.org/project/brainreg-napari)
 [![Wheel](https://img.shields.io/pypi/wheel/brainreg-napari.svg)](https://pypi.org/project/brainreg-napari)

--- a/brainreg_napari/__init__.py
+++ b/brainreg_napari/__init__.py
@@ -1,0 +1,6 @@
+import warnings
+
+warnings.warn(
+    "brainreg-napari is deprecated, please switch to brainreg[napari].",
+    DeprecationWarning,
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,8 @@
 [project]
 name = "brainreg-napari"
-authors = [{name = "Adam Tyson, Stephen Lenzi", email= "code@adamltyson.com"}]
+authors = [
+    { name = "Adam Tyson, Stephen Lenzi", email = "code@adamltyson.com" },
+]
 description = "Multi-atlas whole-brain microscopy registration"
 readme = "README.md"
 requires-python = ">=3.9.0"
@@ -17,32 +19,32 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Operating System :: OS Independent",
-    ]
+]
 
-license = {text = "BSD-3-Clause"}
+license = { text = "BSD-3-Clause" }
 dependencies = [
     "napari",
     "napari-plugin-engine >= 0.1.4",
     "magicgui",
     "qtpy",
-    "brainglobe-napari-io",
-    "brainreg",
-    "brainreg-segment",
-    "brainglobe-utils",
-    "pooch>1",  # For sample data
+    "brainglobe-napari-io < 1",
+    "brainreg < 1",
+    "brainreg-segment < 1",
+    "brainglobe-utils < 1",
+    "pooch>1",                       # For sample data
 ]
 
 [project.optional-dependencies]
 dev = [
-        "check-manifest",
-        "gitpython",
-        "napari[pyqt5]",
-        "pre-commit",
-        "pytest",
-        "pytest-cov",
-        "pytest-qt",
-        "setuptools_scm",
-        "tox",
+    "check-manifest",
+    "gitpython",
+    "napari[pyqt5]",
+    "pre-commit",
+    "pytest",
+    "pytest-cov",
+    "pytest-qt",
+    "setuptools_scm",
+    "tox",
 ]
 
 [project.urls]
@@ -57,11 +59,7 @@ twitter = "https://twitter.com/brain_globe"
 brainreg-napari = "brainreg_napari:napari.yaml"
 
 [build-system]
-requires = [
-    "setuptools>=45",
-    "wheel",
-    "setuptools_scm[toml]>=6.2",
-]
+requires = ["setuptools>=45", "wheel", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
@@ -73,6 +71,6 @@ line-length = 79
 
 [tool.ruff]
 line-length = 79
-exclude = ["__init__.py","build",".eggs"]
+exclude = ["__init__.py", "build", ".eggs"]
 select = ["I", "E", "F"]
 fix = true


### PR DESCRIPTION
Prepares the `brainreg-napari` package for deprecation following the upcoming merge of `brainreg` and the `napari` plugin.

**What does this PR do?**

- Edits the README to point to the new package
- Adds a deprecation warning when the package is imported
- If install is attempted, fixes `brainglobe` tool versions <1 to attempt to avoid conflicts.

See https://github.com/brainglobe/BrainGlobe/issues/37 for more details.

Documentation changes are staged in the following PR:
- [on bg website repo](https://github.com/brainglobe/brainglobe.github.io/pull/79)

Upon merging this PR, we will:
- Tag a new version, `v0.9`, and push this to PyPI.
- Mark the package as deprecated on PyPI.
- Move outstanding issues to [`brainreg` repository](https://github.com/brainglobe/brainreg).
- Archive this repository