### PR TITLE
Remove napari classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ requires-python = ">=3.9.0"
 dynamic = ["version"]
 classifiers = [
     "Development Status :: 4 - Beta",
-    "Framework :: napari",
     "Topic :: Scientific/Engineering :: Image Recognition",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",


### PR DESCRIPTION
See https://github.com/brainglobe/BrainGlobe/issues/57

In fact, closes https://github.com/brainglobe/BrainGlobe/issues/57

Repo to be re-archived after this change.